### PR TITLE
Add in Monoprice Select Mini v2 profile

### DIFF
--- a/fff/monoprice_select_mini_v2/features.lua
+++ b/fff/monoprice_select_mini_v2/features.lua
@@ -1,0 +1,38 @@
+version = 1
+
+bed_size_x_mm = 120
+bed_size_y_mm = 120
+bed_size_z_mm = 120
+nozzle_diameter_mm = 0.4
+
+extruder_count = 1
+
+z_offset   = 0.0
+
+priming_mm_per_sec = 40
+
+z_layer_height_mm_min = 0.05
+z_layer_height_mm_max = nozzle_diameter_mm * 0.75
+
+print_speed_mm_per_sec_min = 5
+print_speed_mm_per_sec_max = 50
+
+bed_temp_degree_c = 50
+bed_temp_degree_c_min = 0
+bed_temp_degree_c_max = 100
+
+perimeter_print_speed_mm_per_sec_min = 5
+perimeter_print_speed_mm_per_sec_max = 50
+
+first_layer_print_speed_mm_per_sec = 10
+first_layer_print_speed_mm_per_sec_min = 1
+first_layer_print_speed_mm_per_sec_max = 50
+
+for i=0,63,1 do
+  _G['filament_diameter_mm_'..i] = 1.75
+  _G['filament_priming_mm_'..i] = 4.0
+  _G['extruder_temp_degree_c_' ..i] = 210
+  _G['extruder_temp_degree_c_'..i..'_min'] = 150
+  _G['extruder_temp_degree_c_'..i..'_max'] = 270
+  _G['extruder_mix_count_'..i] = 1
+end

--- a/fff/monoprice_select_mini_v2/footer.gcode
+++ b/fff/monoprice_select_mini_v2/footer.gcode
@@ -1,0 +1,8 @@
+G0 X0 Y127;(Stick out the part)
+M190 S0;(Turn off heat bed, don't wait.)
+G92 E10;(Set extruder to 10)
+G1 E7 F200;(retract 3mm)
+M104 S0;(Turn off nozzle, don't wait)
+G4 S300;(Delay 5 minutes)
+M107;(Turn off part fan)
+M84;(Turn off stepper motors.)

--- a/fff/monoprice_select_mini_v2/header.gcode
+++ b/fff/monoprice_select_mini_v2/header.gcode
@@ -1,0 +1,18 @@
+M190 S<HBPTEMP>; Heated bed temp
+M104 S<TOOLTEMP>; Material print temperature
+M109 S<TOOLTEMP>; Material print temperature
+M82; Absolute extrusion mode
+
+G21;(metric values)
+G90;(absolute positioning)
+M82;(set extruder to absolute mode)
+M107;(start with the fan off)
+G28;(Home the printer)
+G92 E0;(Reset the extruder to 0)
+G0 Z5 E5 F500;(Move up and prime the nozzle)
+G0 X-1 Z0;(Move outside the printable area)
+G1 Y60 E8 F500;(Draw a priming/wiping line to the rear)
+G1 X-1;(Move a little closer to the print area)
+G1 Y10 E16 F500;(draw more priming/wiping)
+G1 E15 F250;(Small retract)
+G92 E0;(Zero the extruder)

--- a/fff/monoprice_select_mini_v2/materials/abs.lua
+++ b/fff/monoprice_select_mini_v2/materials/abs.lua
@@ -1,0 +1,9 @@
+name_en = "ABS"
+name_es = "ABS"
+name_fr = "ABS"
+
+extruder_temp_degree_c_0 = 230
+filament_diameter_mm_0 = 1.75
+filament_priming_mm_0 = 1.0
+
+bed_temp_degree_c = 60

--- a/fff/monoprice_select_mini_v2/materials/pla.lua
+++ b/fff/monoprice_select_mini_v2/materials/pla.lua
@@ -1,0 +1,9 @@
+name_en = "PLA"
+name_es = "PLA"
+name_fr = "PLA"
+
+extruder_temp_degree_c_0 = 210
+filament_diameter_mm_0 = 1.75
+filament_priming_mm_0 = 3.0
+
+bed_temp_degree_c = 50

--- a/fff/monoprice_select_mini_v2/printer.lua
+++ b/fff/monoprice_select_mini_v2/printer.lua
@@ -1,0 +1,93 @@
+-- Generic reprap
+
+version = 1
+
+function comment(text)
+  output('; ' .. text)
+end
+
+extruder_e = 0
+extruder_e_restart = 0
+
+function header()
+  h = file('header.gcode')
+  h = h:gsub( '<TOOLTEMP>', extruder_temp_degree_c[extruders[0]] )
+  h = h:gsub( '<HBPTEMP>', bed_temp_degree_c )
+  output(h)
+end
+
+function footer()
+  output(file('footer.gcode'))
+end
+
+function layer_start(zheight)
+  comment('<layer>')
+  output('G1 Z' .. f(zheight))
+end
+
+function layer_stop()
+  extruder_e_restart = extruder_e
+  output('G92 E0')
+  comment('</layer>')
+end
+
+function retract(extruder,e)
+  len   = filament_priming_mm[extruder]
+  speed = priming_mm_per_sec * 60;
+  letter = 'E'
+  output('G1 F' .. speed .. ' ' .. letter .. f(e - len - extruder_e_restart))
+  extruder_e = e - len
+  return e - len
+end
+
+function prime(extruder,e)
+  len   = filament_priming_mm[extruder]
+  speed = priming_mm_per_sec * 60;
+  letter = 'E'
+  output('G1 F' .. speed .. ' ' .. letter .. f(e + len - extruder_e_restart))
+  extruder_e = e + len
+  return e + len
+end
+
+current_extruder = 0
+current_frate = 0
+
+function select_extruder(extruder)
+end
+
+function swap_extruder(from,to,x,y,z)
+end
+
+function move_xyz(x,y,z)
+  output('G1 X' .. f(x) .. ' Y' .. f(y) .. ' Z' .. f(z+z_offset))
+end
+
+function move_xyze(x,y,z,e)
+  extruder_e = e
+  letter = 'E'
+  output('G1 X' .. f(x) .. ' Y' .. f(y) .. ' Z' .. f(z+z_offset) .. ' F' .. current_frate .. ' ' .. letter .. f(e - extruder_e_restart))
+end
+
+function move_e(e)
+  extruder_e = e
+  letter = 'E'
+  output('G1 ' .. letter .. f(e - extruder_e_restart))
+end
+
+function set_feedrate(feedrate)
+  output('G1 F' .. feedrate)
+  current_frate = feedrate
+end
+
+function extruder_start()
+end
+
+function extruder_stop()
+end
+
+function progress(percent)
+end
+
+function set_extruder_temperature(extruder,temperature)
+  output('M104 S' .. temperature .. ' T' .. extruder)
+end

--- a/fff/monoprice_select_mini_v2/profiles/high.lua
+++ b/fff/monoprice_select_mini_v2/profiles/high.lua
@@ -1,0 +1,31 @@
+name_en = "High quality"
+name_es = "Alta calidad"
+name_fr = "Haute qualité"
+
+z_layer_height_mm = 0.0875
+
+print_speed_mm_per_sec=20
+first_layer_print_speed_mm_per_sec=10
+perimeter_print_speed_mm_per_sec=15
+travel_speed_mm_per_sec=80
+priming_mm_per_sec=30
+
+add_raft=false
+raft_spacing=1.0
+
+gen_supports=false
+support_extruder=0
+
+add_brim=true
+brim_distance_to_print=1.0
+brim_num_contours=4
+
+extruder_0=0
+num_shells_0=1
+num_covers_0=6
+print_perimeter_0=true
+infill_percentage_0=20
+flow_multiplier_0=1.0
+speed_multiplier_0=1.0
+
+process_thin_features=false

--- a/fff/monoprice_select_mini_v2/profiles/low.lua
+++ b/fff/monoprice_select_mini_v2/profiles/low.lua
@@ -1,0 +1,31 @@
+name_en = "Fast print"
+name_es = "Impresión rápida"
+name_fr = "Impression rapide"
+
+z_layer_height_mm = 0.21875
+
+print_speed_mm_per_sec=40
+first_layer_print_speed_mm_per_sec=10
+perimeter_print_speed_mm_per_sec=40
+travel_speed_mm_per_sec=80
+priming_mm_per_sec=30
+
+add_raft=false
+raft_spacing=1.0
+
+gen_supports=false
+support_extruder=0
+
+add_brim=true
+brim_distance_to_print=1.0
+brim_num_contours=4
+
+extruder_0=0
+num_shells_0=0
+num_covers_0=3
+print_perimeter_0=true
+infill_percentage_0=15
+flow_multiplier_0=1.0
+speed_multiplier_0=1.0
+
+process_thin_features=false

--- a/fff/monoprice_select_mini_v2/profiles/medium.lua
+++ b/fff/monoprice_select_mini_v2/profiles/medium.lua
@@ -1,0 +1,31 @@
+name_en = "Standard quality"
+name_es = "Calidad estándar"
+name_fr = "Qualité standard"
+
+z_layer_height_mm = 0.13125
+
+print_speed_mm_per_sec=30
+first_layer_print_speed_mm_per_sec=10
+perimeter_print_speed_mm_per_sec=20
+travel_speed_mm_per_sec=80
+priming_mm_per_sec=30
+
+add_raft=false
+raft_spacing=1.0
+
+gen_supports=false
+support_extruder=0
+
+add_brim=true
+brim_distance_to_print=1.0
+brim_num_contours=4
+
+extruder_0=0
+num_shells_0=1
+num_covers_0=6
+print_perimeter_0=true
+infill_percentage_0=20
+flow_multiplier_0=1.0
+speed_multiplier_0=1.0
+
+process_thin_features=false


### PR DESCRIPTION
This adds in Contains the magic numbers for High (z-layer 0.0875), Medium (z-layer 0.13125), and Low (z-layer 0.21875) profiles as well as PLA and ABS materials.